### PR TITLE
RedisConsumer will now capture exceptions in the message handler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     minitest (5.18.0)
+    mock_redis (0.45.0)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
@@ -90,6 +91,7 @@ PLATFORMS
 DEPENDENCIES
   brakeman (~> 5.4)
   chippy!
+  mock_redis (~> 0.45.0)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.44)

--- a/chippy.gemspec
+++ b/chippy.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop-performance", "~> 1.15"
   s.add_development_dependency "rubocop-rake", "~> 0.6.0"
   s.add_development_dependency "timecop", "~> 0.9.6"
+  s.add_development_dependency "mock_redis", "~> 0.45.0"
   s.files = Dir["lib/**/*", "README.md", "CHANGELOG.md", "chippy.png"]
 end

--- a/lib/chippy/client/redis_consumer.rb
+++ b/lib/chippy/client/redis_consumer.rb
@@ -9,9 +9,9 @@ module Chippy
         yield self
       end
 
-      def initialize(queue_name = nil, &block)
+      def initialize(queue_name = nil, redis = nil, &block)
         @queue_name = queue_name || self.class.queue_name
-        @redis = Redis.new
+        @redis = redis || Redis.new
         @message_handler = block || self.class.message_handler
       end
 
@@ -22,6 +22,8 @@ module Chippy
             _, message = @redis.blpop(@queue_name, timeout: 0)
 
             handle_message(message)
+          rescue => error
+            Sentry.capture_exception(error)
           end
         end
       end


### PR DESCRIPTION
This will ensure the listener thread will not crash on exceptions.

Due to some strange queue issues with redis in tests i added redis-mock and allow to inject it into RedisConsumer.

The specs pass if you run them one by one with just normal Redis e.g.
`bundle exec rspec spec/chippy/client/redis_consumer_spec.rb:33`
but if you run them all in one go e.g. 
`bundle exec rspec spec/chippy/client/redis_consumer_spec.rb`
They would fail, using mock redis solves this.